### PR TITLE
Use dup instead of pre-populating hash

### DIFF
--- a/lib/active_record_stats.rb
+++ b/lib/active_record_stats.rb
@@ -3,9 +3,6 @@ require 'active_record'
 require 'statsd-instrument'
 
 module ActiveRecordStats
-  STATEMENT_KEYS = %w[BEGIN COMMIT DELETE EXPLAIN INSERT
-    RELEASE ROLLBACK SAVEPOINT SELECT UPDATE WITH].freeze
-
   def self.statement_type(sql)
     return if sql.nil?
 
@@ -14,11 +11,5 @@ module ActiveRecordStats
 
     type = cleaned.split(' ', 2).first
     type.try(:upcase)
-  end
-
-  def self.statement_hash
-    hash = {}
-    STATEMENT_KEYS.each { |k| hash[k] = 0 }
-    hash
   end
 end

--- a/lib/active_record_stats/rack_middleware.rb
+++ b/lib/active_record_stats/rack_middleware.rb
@@ -44,7 +44,7 @@ module ActiveRecordStats
       if request_params && controller = request_params['controller']
         controller = controller.gsub('/', '__')
         action = request_params['action']
-        emit(controller, action, db_time, totals)
+        emit(controller, action, db_time, totals.dup)
       end
     end
 

--- a/lib/active_record_stats/rack_middleware.rb
+++ b/lib/active_record_stats/rack_middleware.rb
@@ -14,7 +14,7 @@ module ActiveRecordStats
     end
 
     def call(env)
-      totals  = ActiveRecordStats.statement_hash
+      totals  = {}
       db_time = 0
 
       gather_sql = ->(_name, _started_at, _finished_at, _unique_id, payload) {

--- a/lib/active_record_stats/resque_plugin.rb
+++ b/lib/active_record_stats/resque_plugin.rb
@@ -3,7 +3,7 @@ require 'active_record_stats'
 module ActiveRecordStats
   module ResquePlugin
     def around_perform_active_record_stats(*args, &block)
-      totals = ActiveRecordStats.statement_hash
+      totals = {}
 
       gather_sql = ->(_name, _started_at, _finished_at, _unique_id, payload) {
         return if payload[:name] == 'SCHEMA' || payload[:sql].blank?

--- a/lib/active_record_stats/resque_plugin.rb
+++ b/lib/active_record_stats/resque_plugin.rb
@@ -17,7 +17,7 @@ module ActiveRecordStats
 
     ensure
       ActiveSupport::Notifications.unsubscribe(sub)
-      emit_active_record_stats(name, totals)
+      emit_active_record_stats(name, totals.dup)
     end
 
     private

--- a/lib/active_record_stats/sidekiq_server_middleware.rb
+++ b/lib/active_record_stats/sidekiq_server_middleware.rb
@@ -3,8 +3,8 @@ require 'active_record_stats'
 module ActiveRecordStats
   class SidekiqServerMiddleware
     def call(worker, job, queue)
-      totals = ActiveRecordStats.statement_hash
-      
+      totals = {}
+
       gather_sql = ->(_name, _started_at, _finished_at, _unique_id, payload) {
         return if payload[:name] == 'SCHEMA' || payload[:sql].blank?
         return unless type = ActiveRecordStats.statement_type(payload[:sql])

--- a/lib/active_record_stats/sidekiq_server_middleware.rb
+++ b/lib/active_record_stats/sidekiq_server_middleware.rb
@@ -17,7 +17,7 @@ module ActiveRecordStats
 
     ensure
       ActiveSupport::Notifications.unsubscribe(sub)
-      emit(worker.class.to_s, totals)
+      emit(worker.class.to_s, totals.dup)
     end
 
     private

--- a/lib/active_record_stats/version.rb
+++ b/lib/active_record_stats/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordStats
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
💚 

Probably a better plan than pre-populating the hash since it doesn't require the gem to know what different commands are possible and it does the work after the worker has already completed instead of frontloading.
