### PR TITLE
ActiveRecord::Notifications doesn't always add this key

### DIFF
--- a/lib/active_record_stats/rack_middleware.rb
+++ b/lib/active_record_stats/rack_middleware.rb
@@ -26,7 +26,7 @@ module ActiveRecordStats
       }
 
       gather_runtime = ->(_name, _started_at, _finished_at, _unique_id, payload) {
-        db_time = payload[:db_runtime]
+        db_time = payload[:db_runtime] || 0
       }
 
       subs = [


### PR DESCRIPTION
One possible solution to https://github.com/enova/active_record_stats/issues/3

---

In Rails 5.0.1, the `:db_runtime` key isn't guaranteed to be present in a typical non-development environment (i.e. `staging`, `production`) for the `ActiveSupport::Notifications` => `process_action.action_controller` event. You can reproduce this fact by:

* install this gem in your app
* start your app in a non-development environment
* hit any action in your app that **DOES NOT** query the database (but it must be the first action you hit after starting the app)

Before your database is queried for the first time after starting, the `:db_runtime` key will not be present in the event payload. After your first db query via ActiveRecord it will always be present until the app is restarted.

Therefore, it's guaranteed that:

* If this key is missing
* Then the actual DB time is, in fact, `0`

... I think it's safe to default `db_time` to `0` when the key is missing.

### Other considerations:

Since the behavior exhibits itself differently depending on the Rails environment, it seems logical that a change in the environment config could also address this issue, and that may be the case. What I haven't figured out yet is if it's the app that should change, or if the different behavior based on environment is **intended** by ActiveSupport and the app/gem should adapt to that fact.

Either way, assuming `0` for this value when the key is missing appears to be 100% safe in any case where it happens.

Open to alternate solutions.